### PR TITLE
Port to MC 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.neoforged.gradle.userdev' version '7.0.45'
+    id 'net.neoforged.gradle.userdev' version '7.0.71'
     id "com.modrinth.minotaur" version "2.+"
     id 'net.darkhax.curseforgegradle' version '1.+'
 }
@@ -121,7 +121,7 @@ if (file('key.properties').exists()) {
         mainFile.changelog = file("changelog.txt")
         mainFile.addModLoader("NeoForge")
         mainFile.addJavaVersion("Java 17")
-        mainFile.addGameVersion("1.20.2")
+        mainFile.addGameVersion("1.20.4")
     }
 }
 
@@ -135,7 +135,7 @@ if (file('key.properties').exists()) {
         versionNumber = project.mod_version
         uploadFile = jar
         changelog = rootProject.file("changelog.txt").text
-        gameVersions = ['1.20.2']
+        gameVersions = ['1.20.4']
         loaders = ['neoforge']
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,19 +2,19 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-minecraft_version=1.20.2
-minecraft_version_range=[1.20.2,1.20.3)
-neo_version=20.2.59-beta
-neo_version_range=[20.2,)
+minecraft_version=1.20.4
+minecraft_version_range=[1.20.4,1.20.5)
+neo_version=20.4.49-beta
+neo_version_range=[20.4,)
 loader_version_range=[1,)
 mapping_channel=official
-mapping_version=1.20.2
+mapping_version=1.20.4
 ## Mod Properties
 mod_id=cpapireforged
 mod_name=Custom Portal API ReForged
 mod_license=MIT
-mod_version=1.0.3
-version=1.0.3
+mod_version=1.0.4
+version=1.0.4
 mod_group_id=net.kyrptonaught.customportalapi
 mod_authors=AzureDoom, kyrptonaught, Waterpicker, Mysticpasta1
 mod_description=Create portals out of anything!

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/kyrptonaught/customportalapi/CustomPortalsMod.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/CustomPortalsMod.java
@@ -39,7 +39,7 @@ public class CustomPortalsMod {
 
     public static DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, MOD_ID);
 
-    public static final Supplier<CustomPortalBlock> portalBlock = BLOCKS.register("custom_portal_block", () -> new CustomPortalBlock(Block.Properties.copy(Blocks.NETHER_PORTAL).noCollission().strength(-1).sound(SoundType.GLASS).lightLevel(state -> 11)));
+    public static final Supplier<CustomPortalBlock> portalBlock = BLOCKS.register("custom_portal_block", () -> new CustomPortalBlock(Block.Properties.ofFullCopy(Blocks.NETHER_PORTAL).noCollission().strength(-1).sound(SoundType.GLASS).lightLevel(state -> 11)));
     public static HashMap<ResourceLocation, ResourceKey<Level>> dims = new HashMap<>();
     public static ResourceLocation VANILLAPORTAL_FRAMETESTER = new ResourceLocation(MOD_ID, "vanillanether");
     public static ResourceLocation FLATPORTAL_FRAMETESTER = new ResourceLocation(MOD_ID, "flat");
@@ -69,8 +69,8 @@ public class CustomPortalsMod {
                 var hit = player.pick(6, 1, false);
                 if (hit.getType() == HitResult.Type.BLOCK) {
                     var blockHit = (BlockHitResult) hit;
-                    if (PortalPlacer.attemptPortalLight(world, blockHit.getBlockPos().relative(blockHit.getDirection()), PortalIgnitionSource.ItemUseSource(item)))
-                        event.setResult(Event.Result.ALLOW);
+                    if (!PortalPlacer.attemptPortalLight(world, blockHit.getBlockPos().relative(blockHit.getDirection()), PortalIgnitionSource.ItemUseSource(item)))
+                        event.setCanceled(true);
                 }
             }
         }

--- a/src/main/java/net/kyrptonaught/customportalapi/api/CustomPortalBuilder.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/api/CustomPortalBuilder.java
@@ -77,7 +77,7 @@ public class CustomPortalBuilder {
     /**
      * Specify the color to be used to tint the portal block.
      *
-     * @param color Single Color int value used for tinting. See {@link net.minecraft.util.DyeColor}
+     * @param color Single Color int value used for tinting. See {@link net.minecraft.util.ColorRGBA}
      */
     public CustomPortalBuilder tintColor(int color) {
         portalLink.colorID = color;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -10,13 +10,13 @@ authors="${mod_authors}"
 description='''${mod_description}'''
 [[dependencies.${mod_id}]] 
     modId="neoforge"
-    mandatory=true 
+    type = "required" 
     versionRange="${neo_version_range}" 
     ordering="NONE"
     side="BOTH"
 [[dependencies.${mod_id}]]
     modId="minecraft"
-    mandatory=true
+    type = "required"
     versionRange="${minecraft_version_range}"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
This PR ports to MC 1.20.4 on NeoForge 20.4.49-beta. 
It also includes a related NeoGradle update to 7.0.71 and Gradle to 8.5.

Tested in a workspace with one of my mods.
![image](https://github.com/AzureDoom/customportalapi-reforged/assets/48810167/e3e6c6d5-b1ef-4c64-a47d-d232653a402f)

Since there is no main branch in this repository, it is currently targeting the `1.20.2` branch that it was based on.