### PR TITLE
Upstream Parity Patch

### DIFF
--- a/src/main/java/net/kyrptonaught/customportalapi/CustomPortalsMod.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/CustomPortalsMod.java
@@ -126,7 +126,7 @@ public class CustomPortalsMod {
                         !PortalPlacer.attemptPortalLight(
                             world,
                             blockHit.getBlockPos().relative(blockHit.getDirection()),
-                            PortalIgnitionSource.ItemUseSource(item)
+                            PortalIgnitionSource.ItemUseSource(item).withPlayer(player)
                         )
                     )
                         event.setCanceled(true);

--- a/src/main/java/net/kyrptonaught/customportalapi/CustomPortalsMod.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/CustomPortalsMod.java
@@ -123,7 +123,7 @@ public class CustomPortalsMod {
                 if (hit.getType() == HitResult.Type.BLOCK) {
                     BlockHitResult blockHit = (BlockHitResult) hit;
                     if (
-                        !PortalPlacer.attemptPortalLight(
+                        PortalPlacer.attemptPortalLight(
                             world,
                             blockHit.getBlockPos().relative(blockHit.getDirection()),
                             PortalIgnitionSource.ItemUseSource(item).withPlayer(player)

--- a/src/main/java/net/kyrptonaught/customportalapi/api/CustomPortalBuilder.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/api/CustomPortalBuilder.java
@@ -16,6 +16,8 @@ import net.kyrptonaught.customportalapi.CustomPortalApiRegistry;
 import net.kyrptonaught.customportalapi.CustomPortalBlock;
 import net.kyrptonaught.customportalapi.CustomPortalsMod;
 import net.kyrptonaught.customportalapi.event.CPASoundEventData;
+import net.kyrptonaught.customportalapi.event.PortalIgniteEvent;
+import net.kyrptonaught.customportalapi.event.PortalPreIgniteEvent;
 import net.kyrptonaught.customportalapi.portal.PortalIgnitionSource;
 import net.kyrptonaught.customportalapi.util.ColorUtil;
 import net.kyrptonaught.customportalapi.util.PortalLink;
@@ -229,6 +231,23 @@ public class CustomPortalBuilder {
      */
     public CustomPortalBuilder registerPostTPEvent(Consumer<Entity> event) {
         portalLink.setPostTPEvent(event);
+        return this;
+    }
+
+    /**
+     * Register an event to be called before a portal is lit. PortalPreIgniteEvent returns true if the portal should be
+     * lit, or false if not
+     */
+    public CustomPortalBuilder registerPreIgniteEvent(PortalPreIgniteEvent event) {
+        portalLink.setPortalPreIgniteEvent(event);
+        return this;
+    }
+
+    /**
+     * Register an event to be called after a portal is lit.
+     */
+    public CustomPortalBuilder registerIgniteEvent(PortalIgniteEvent event) {
+        portalLink.setPortalIgniteEvent(event);
         return this;
     }
 }

--- a/src/main/java/net/kyrptonaught/customportalapi/event/PortalIgniteEvent.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/event/PortalIgniteEvent.java
@@ -1,0 +1,13 @@
+package net.kyrptonaught.customportalapi.event;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+
+import net.kyrptonaught.customportalapi.portal.PortalIgnitionSource;
+
+@FunctionalInterface
+public interface PortalIgniteEvent {
+
+    void afterLight(Player player, Level world, BlockPos portalPos, BlockPos framePos, PortalIgnitionSource portalIgnitionSource);
+}

--- a/src/main/java/net/kyrptonaught/customportalapi/event/PortalPreIgniteEvent.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/event/PortalPreIgniteEvent.java
@@ -1,0 +1,13 @@
+package net.kyrptonaught.customportalapi.event;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+
+import net.kyrptonaught.customportalapi.portal.PortalIgnitionSource;
+
+@FunctionalInterface
+public interface PortalPreIgniteEvent {
+
+    boolean attemptLight(Player player, Level world, BlockPos portalPos, BlockPos framePos, PortalIgnitionSource portalIgnitionSource);
+}

--- a/src/main/java/net/kyrptonaught/customportalapi/portal/PortalPlacer.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/portal/PortalPlacer.java
@@ -39,10 +39,17 @@ public class PortalPlacer {
             )
         )
             return false;
-        return createPortal(link, world, portalPos, foundationBlock);
+        return createPortal(link, world, portalPos, foundationBlock, framePos, ignitionSource);
     }
 
-    private static boolean createPortal(PortalLink link, Level world, BlockPos pos, Block foundationBlock) {
+    private static boolean createPortal(
+        PortalLink link,
+        Level world,
+        BlockPos pos,
+        Block foundationBlock,
+        BlockPos framePos,
+        PortalIgnitionSource ignitionSource
+    ) {
         Optional<PortalFrameTester> optional = link.getFrameTester()
             .createInstanceOfPortalFrameTester()
             .getNewPortal(
@@ -53,8 +60,13 @@ public class PortalPlacer {
             );
         // is valid frame, and is correct size(if applicable)
         if (optional.isPresent()) {
-            if (optional.get().isRequestedSize(link.forcedWidth, link.forcedHeight))
+            if (
+                optional.get().isRequestedSize(link.forcedWidth, link.forcedHeight)
+                    && link.getPortalPreIgniteEvent().attemptLight(ignitionSource.player, world, pos, framePos, ignitionSource)
+            ) {
                 optional.get().lightPortal(foundationBlock);
+                link.getPortalIgniteEvent().afterLight(ignitionSource.player, world, pos, framePos, ignitionSource);
+            }
             return true;
         }
         return false;

--- a/src/main/java/net/kyrptonaught/customportalapi/util/PortalLink.java
+++ b/src/main/java/net/kyrptonaught/customportalapi/util/PortalLink.java
@@ -12,6 +12,8 @@ import net.kyrptonaught.customportalapi.CustomPortalBlock;
 import net.kyrptonaught.customportalapi.CustomPortalsMod;
 import net.kyrptonaught.customportalapi.event.CPAEvent;
 import net.kyrptonaught.customportalapi.event.CPASoundEventData;
+import net.kyrptonaught.customportalapi.event.PortalIgniteEvent;
+import net.kyrptonaught.customportalapi.event.PortalPreIgniteEvent;
 import net.kyrptonaught.customportalapi.portal.PortalIgnitionSource;
 import net.kyrptonaught.customportalapi.portal.frame.PortalFrameTester;
 
@@ -46,6 +48,10 @@ public class PortalLink {
     private final CPAEvent<Player, CPASoundEventData> inPortalAmbienceEvent = new CPAEvent<>();
 
     private final CPAEvent<Player, CPASoundEventData> postTpPortalAmbienceEvent = new CPAEvent<>();
+
+    private PortalIgniteEvent portalIgniteEvent = (player, world, portalPos, framePos, portalIgnitionSource) -> {};
+
+    private PortalPreIgniteEvent portalPreIgniteEvent = (player, world, portalPos, framePos, portalIgnitionSource) -> true;
 
     public PortalLink() {}
 
@@ -94,6 +100,22 @@ public class PortalLink {
     public void executePostTPEvent(Entity entity) {
         if (postTPEvent != null)
             postTPEvent.accept(entity);
+    }
+
+    public PortalIgniteEvent getPortalIgniteEvent() {
+        return portalIgniteEvent;
+    }
+
+    public void setPortalIgniteEvent(PortalIgniteEvent portalIgniteEvent) {
+        this.portalIgniteEvent = portalIgniteEvent;
+    }
+
+    public PortalPreIgniteEvent getPortalPreIgniteEvent() {
+        return portalPreIgniteEvent;
+    }
+
+    public void setPortalPreIgniteEvent(PortalPreIgniteEvent portalPreIgniteEvent) {
+        this.portalPreIgniteEvent = portalPreIgniteEvent;
     }
 
     public PortalFrameTester.PortalFrameTesterFactory getFrameTester() {


### PR DESCRIPTION
This PR implements a few changes to have parity with the upstream project, kyrptonaught's customportalapi.

This implements the PortalIgniteEvent and PortalPreIgniteEvent interfaces, as well as their handlers/callers. This allows library users to run custom code before and after the portal is lit, including the capability to cancel lighting the portal.

In the item use event handler, this adds the player entity to the ignition source. This is upstream behavior and allows library users to access the player entity in ignite events.

This also makes what could be a breaking change. Currently, customportalapi-reforged cancels the item usage when lighting the portal fails. This is backwards from upstream, and IMO, an undesirable behavior/bug. The opposite should happen- if the item is used to light the portal- it's normal usage behavior should be cancelled: for example, if I light a portal with an eye of ender, the eye shouldn't also fly off towards the stronghold and possibly break.

For others who may be interested in using these features (In 1.21.1) pending potential acceptance and publishing:
```kts
repositories {
    mavenLocal()
    maven("https://maven.parchmentmc.org") { name = "ParchmentMC" }
    maven("https://maven.azuredoom.com/mods") { name = "AzureDoom" }

    ivy {
        name = "murderspagurder GitHub"
        url = uri("https://github.com/murderspagurder/customportalapi-reforged/releases/download/1.2.1+spagurder.1/")
        patternLayout {
            artifact("[artifact]-[revision].[ext]")
        }
        metadataSources {
            artifact()
        }
    }
}

dependencies {
    implementation("net.kyrptonaught.customportalapi:cpapireforged-neo-1.21.1:1.2.1+spagurder.1")
    jarJar("net.kyrptonaught.customportalapi:cpapireforged-neo-1.21.1:1.2.1+spagurder.1")
}
```